### PR TITLE
fixed an error of is not a string

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,8 +1,9 @@
 import * as utils from "@poppinss/utils";
+import * as assertModule from "@poppinss/utils/assert";
 import string from "./string.js";
 
 export { Encryption } from "@adonisjs/encryption";
 
-type Helpers = typeof utils & { string: typeof string };
+type Helpers = typeof utils & { string: typeof string, assert: typeof  assertModule.assert };
 
-export const helpers = { ...utils, string } as Helpers;
+export const helpers = { ...utils, assert: assertModule.assert, string } as Helpers;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(({ mode }) => {
 				fileName: "index",
 			},
 			rollupOptions: {
-				external: ["node:fs", "node:fs/promises", "node:util", "node:path", "node:url", "node:buffer", "node:crypto"],
+				external: ["node:fs", "node:fs/promises", "node:util", "node:path", "node:url", "node:buffer", "node:crypto", "node:assert", "@poppinss/utils","@poppinss/utils/string","@adonisjs/encryption", '@poppinss/utils/assert',"assert",],
 			},
 		},
 


### PR DESCRIPTION
Added some external dependencies to rollupOptions externals array list as these were causing minified name issue due to multiple 'assert' functions from  node:assert, '@poppinss/utils/assert' and "assert". 